### PR TITLE
Unstale on push

### DIFF
--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,6 +1,6 @@
 name: Remove Labels
 
-on: [issue_comment, pull_request]
+on: [issue_comment, pull_request, push]
 
 permissions:
   contents: read


### PR DESCRIPTION
This should fix https://github.com/qgis/QGIS/issues/52755

From https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push:

> Runs your workflow when you push a commit or tag.